### PR TITLE
Only 'deploy' if a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,6 @@ on:
 jobs:
   build-package:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/por-que
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
@@ -28,5 +23,29 @@ jobs:
         run: uv pip install build
       - name: Build
         run: .venv/bin/python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags')
+        with:
+          name: dist-{github.ref}
+          path: dist/
+          overwrite: true
+          if-no-files-found: error
+
+  release-package:
+    if: startsWith(github.ref, 'refs/tags')
+    needs: build-package
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/por-que
+    permissions:
+      id-token: write
+    steps:
+      - name: Download a single artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: dist-{github.ref}
+          path: dist/
+      - name: Upload release
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Splits releasing into build and release jobs, so we can build without it looking like a "deployment" to pypi every time.